### PR TITLE
Табуляция на css

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -9,3 +9,7 @@
 @import "../../components/container/container.css";
 @import "../../components/card/card.css";
 @import "../../components/tabs/tabs.css";
+
+html, body {
+    height: 100%;
+}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -8,3 +8,4 @@
 @import "../../components/preview/preview.css";
 @import "../../components/container/container.css";
 @import "../../components/card/card.css";
+@import "../../components/tabs/tabs.css";

--- a/components/header/header.css
+++ b/components/header/header.css
@@ -14,7 +14,7 @@
 }
 
 .header_main {
-    padding: 25px 0 77px 0;
+    padding: 25px 0 40px 0;
 }
 
 .header_template {

--- a/components/page/page.css
+++ b/components/page/page.css
@@ -1,5 +1,4 @@
 .page {
-    max-width: 1440px;
     margin: 0 auto;
 
     display: flex;

--- a/components/page/page.css
+++ b/components/page/page.css
@@ -1,9 +1,8 @@
 .page {
     margin: 0 auto;
 
-    display: flex;
-    flex-direction: column;
-
+    display: grid;
+    grid-template-rows: auto 1fr auto;
     height: 100%;
 }
 

--- a/components/preview/preview.css
+++ b/components/preview/preview.css
@@ -1,6 +1,4 @@
 .preview {
-    background-color: #F9FAFC;
-    padding: 68px 0;
 }
 
 .preview__cards {

--- a/components/tabs/tabs.css
+++ b/components/tabs/tabs.css
@@ -1,0 +1,114 @@
+.tabs {
+}
+
+.tabs__scroller {
+    display: grid;
+    grid-template-columns: repeat(4, auto);
+    row-gap: 8px;
+    column-gap: 40px;
+    justify-content: start;
+    background-color: var(--white);
+    color: var(--grey-3);
+    font-family: Inter;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px;
+}
+
+.tabs__menu-selector {
+    background-color: transparent;
+    height: 5px;
+}
+
+.tabs__content {
+    background-color: #F9FAFC;
+    padding: 40px 0 0 0;
+    display: flex;
+    flex-grow: 1;
+    flex-wrap: wrap;
+    gap: 30px;
+}
+
+@media screen and (max-width: 375px) {
+    .tabs__content {
+        gap: 16px;
+    }
+}
+
+.tabs__content_element {
+    display: none;
+}
+
+.tabs__content_container {
+    display: none;
+}
+
+.tabs__content_template {
+    display: none;
+}
+
+.tabs__menu-label {
+    cursor: pointer;
+}
+
+.tabs__menu-item {
+    position: absolute;
+    left: -100vw;
+}
+
+.tabs__menu-item-all:checked ~ .tabs__content {
+    display: flex;
+}
+
+.tabs__menu-item-element:checked ~ .tabs__content_element {
+    display: flex;
+}
+
+.tabs__menu-item-container:checked ~ .tabs__content_container {
+    display: flex;
+}
+
+.tabs__menu-item-template:checked ~ .tabs__content_template {
+    display: flex;
+}
+
+.tabs__menu-item-all:checked ~ .tabs__scroller
+.tabs__menu-selector-all {
+    background-color: var(--black);
+}
+
+.tabs__menu-item-element:checked ~ .tabs__scroller
+.tabs__menu-selector-element {
+    background-color: var(--black);
+}
+
+.tabs__menu-item-container:checked ~ .tabs__scroller
+.tabs__menu-selector-container {
+    background-color: var(--black);
+}
+
+.tabs__menu-item-template:checked ~ .tabs__scroller
+.tabs__menu-selector-template {
+    background-color: var(--black);
+}
+
+.tabs__menu-item-all:focus ~ .tabs__scroller
+.tabs__menu-label-all {
+    text-decoration: underline;
+}
+
+.tabs__menu-item-element:focus ~ .tabs__scroller
+.tabs__menu-label-element {
+    text-decoration: underline;
+}
+
+.tabs__menu-item-container:focus ~ .tabs__scroller
+.tabs__menu-label-container {
+    text-decoration: underline;
+}
+
+.tabs__menu-item-template:focus ~ .tabs__scroller
+.tabs__menu-label-template {
+    text-decoration: underline;
+}

--- a/components/tabs/tabs.css
+++ b/components/tabs/tabs.css
@@ -1,4 +1,11 @@
 .tabs {
+    height: 100%;
+    flex-grow: 1;
+}
+
+.tabs__main {
+    background-color: #F9FAFC;
+    padding-bottom: 92px;
 }
 
 .tabs__scroller {
@@ -22,7 +29,6 @@
 }
 
 .tabs__content {
-    background-color: #F9FAFC;
     padding: 40px 0 0 0;
     display: flex;
     flex-grow: 1;
@@ -32,6 +38,12 @@
 
 @media screen and (max-width: 375px) {
     .tabs__content {
+        column-gap: 24px;
+    }
+}
+
+@media screen and (max-width: 375px) {
+    .tabs__scroller {
         gap: 16px;
     }
 }
@@ -50,6 +62,7 @@
 
 .tabs__menu-label {
     cursor: pointer;
+    white-space: nowrap;
 }
 
 .tabs__menu-item {
@@ -57,58 +70,62 @@
     left: -100vw;
 }
 
-.tabs__menu-item-all:checked ~ .tabs__content {
+.tabs__menu-item_all:checked ~ .tabs__main .container
+.tabs__content {
     display: flex;
 }
 
-.tabs__menu-item-element:checked ~ .tabs__content_element {
+.tabs__menu-item_element:checked ~ .tabs__main .container
+.tabs__content_element {
     display: flex;
 }
 
-.tabs__menu-item-container:checked ~ .tabs__content_container {
+.tabs__menu-item_container:checked ~ .tabs__main .container
+.tabs__content_container {
     display: flex;
 }
 
-.tabs__menu-item-template:checked ~ .tabs__content_template {
+.tabs__menu-item_template:checked ~ .tabs__main .container
+.tabs__content_template {
     display: flex;
 }
 
-.tabs__menu-item-all:checked ~ .tabs__scroller
-.tabs__menu-selector-all {
+.tabs__menu-item_all:checked ~ .container .tabs__scroller
+.tabs__menu-selector_all {
     background-color: var(--black);
 }
 
-.tabs__menu-item-element:checked ~ .tabs__scroller
-.tabs__menu-selector-element {
+.tabs__menu-item_element:checked ~ .container .tabs__scroller
+.tabs__menu-selector_element {
     background-color: var(--black);
 }
 
-.tabs__menu-item-container:checked ~ .tabs__scroller
-.tabs__menu-selector-container {
+.tabs__menu-item_container:checked ~ .container .tabs__scroller
+.tabs__menu-selector_container {
     background-color: var(--black);
 }
 
-.tabs__menu-item-template:checked ~ .tabs__scroller
-.tabs__menu-selector-template {
+.tabs__menu-item_template:checked ~ .container .tabs__scroller
+.tabs__menu-selector_template {
     background-color: var(--black);
 }
 
-.tabs__menu-item-all:focus ~ .tabs__scroller
-.tabs__menu-label-all {
+.tabs__menu-item_all:focus ~ .container .tabs__scroller
+.tabs__menu-label_all {
     text-decoration: underline;
 }
 
-.tabs__menu-item-element:focus ~ .tabs__scroller
-.tabs__menu-label-element {
+.tabs__menu-item_element:focus ~ .container .tabs__scroller
+.tabs__menu-label_element {
     text-decoration: underline;
 }
 
-.tabs__menu-item-container:focus ~ .tabs__scroller
-.tabs__menu-label-container {
+.tabs__menu-item_container:focus ~ .container .tabs__scroller
+.tabs__menu-label_container {
     text-decoration: underline;
 }
 
-.tabs__menu-item-template:focus ~ .tabs__scroller
-.tabs__menu-label-template {
+.tabs__menu-item_template:focus ~ .container .tabs__scroller
+.tabs__menu-label_template {
     text-decoration: underline;
 }

--- a/components/tabs/tabs.css
+++ b/components/tabs/tabs.css
@@ -1,6 +1,5 @@
 .tabs {
     height: 100%;
-    flex-grow: 1;
 }
 
 .tabs__main {
@@ -15,12 +14,6 @@
     column-gap: 40px;
     justify-content: start;
     background-color: var(--white);
-    color: var(--grey-3);
-    font-family: Inter;
-    font-size: 16px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 24px;
 }
 
 .tabs__menu-selector {
@@ -61,6 +54,13 @@
 }
 
 .tabs__menu-label {
+    color: var(--grey-3);
+    font-family: Inter;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px;
+
     cursor: pointer;
     white-space: nowrap;
 }
@@ -90,25 +90,10 @@
     display: flex;
 }
 
-.tabs__menu-item_all:checked ~ .container .tabs__scroller
-.tabs__menu-selector_all {
+.tabs__menu-item:checked ~ .tabs__menu-selector {
     background-color: var(--black);
 }
 
-.tabs__menu-item_element:checked ~ .container .tabs__scroller
-.tabs__menu-selector_element {
-    background-color: var(--black);
-}
-
-.tabs__menu-item_container:checked ~ .container .tabs__scroller
-.tabs__menu-selector_container {
-    background-color: var(--black);
-}
-
-.tabs__menu-item_template:checked ~ .container .tabs__scroller
-.tabs__menu-selector_template {
-    background-color: var(--black);
-}
 
 .tabs__menu-item_all:focus ~ .container .tabs__scroller
 .tabs__menu-label_all {

--- a/components/tabs/tabs.css
+++ b/components/tabs/tabs.css
@@ -2,18 +2,16 @@
     height: 100%;
 }
 
-.tabs__main {
-    background-color: #F9FAFC;
-    padding-bottom: 92px;
-}
-
 .tabs__scroller {
     display: grid;
     grid-template-columns: repeat(4, auto);
     row-gap: 8px;
     column-gap: 40px;
     justify-content: start;
-    background-color: var(--white);
+
+    max-width: 1110px;
+    margin: 0 auto;
+    padding: 0 15px 0 16px;
 }
 
 .tabs__menu-selector {
@@ -22,7 +20,8 @@
 }
 
 .tabs__content {
-    padding: 40px 0 0 0;
+    background-color: #F9FAFC;
+    padding: 40px 0 92px 0;
     display: flex;
     flex-grow: 1;
     flex-wrap: wrap;
@@ -70,47 +69,58 @@
     left: -100vw;
 }
 
-.tabs__menu-item_all:checked ~ .tabs__main .container
-.tabs__content {
+.tabs__menu-item_all:checked ~ .tabs__content {
     display: flex;
 }
 
-.tabs__menu-item_element:checked ~ .tabs__main .container
-.tabs__content_element {
+.tabs__menu-item_element:checked ~ .tabs__content_element {
     display: flex;
 }
 
-.tabs__menu-item_container:checked ~ .tabs__main .container
-.tabs__content_container {
+.tabs__menu-item_container:checked ~ .tabs__content_container {
     display: flex;
 }
 
-.tabs__menu-item_template:checked ~ .tabs__main .container
-.tabs__content_template {
+.tabs__menu-item_template:checked ~ .tabs__content_template {
     display: flex;
 }
 
-.tabs__menu-item:checked ~ .tabs__menu-selector {
+.tabs__menu-item_all:checked ~ .tabs__scroller
+.tabs__menu-selector_all {
     background-color: var(--black);
 }
 
+.tabs__menu-item_element:checked ~ .tabs__scroller
+.tabs__menu-selector_element {
+    background-color: var(--black);
+}
 
-.tabs__menu-item_all:focus ~ .container .tabs__scroller
+.tabs__menu-item_container:checked ~ .tabs__scroller
+.tabs__menu-selector_container {
+    background-color: var(--black);
+}
+
+.tabs__menu-item_template:checked ~ .tabs__scroller
+.tabs__menu-selector_template {
+    background-color: var(--black);
+}
+
+.tabs__menu-item_all:focus ~ .tabs__scroller
 .tabs__menu-label_all {
     text-decoration: underline;
 }
 
-.tabs__menu-item_element:focus ~ .container .tabs__scroller
+.tabs__menu-item_element:focus ~ .tabs__scroller
 .tabs__menu-label_element {
     text-decoration: underline;
 }
 
-.tabs__menu-item_container:focus ~ .container .tabs__scroller
+.tabs__menu-item_container:focus ~ .tabs__scroller
 .tabs__menu-label_container {
     text-decoration: underline;
 }
 
-.tabs__menu-item_template:focus ~ .container .tabs__scroller
+.tabs__menu-item_template:focus ~ .tabs__scroller
 .tabs__menu-label_template {
     text-decoration: underline;
 }

--- a/index.html
+++ b/index.html
@@ -23,25 +23,27 @@
                     <h1 class="header__title">Reusable component library</h1>
                 </div>
             </header>
-            <main class="preview page__main">
+            <main class="tabs">
+                <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_all" id="#all-tab" checked>
+                <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_element" id="#element-tab">
+                <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_container" id="#container-tab">
+                <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_template" id="#template-tab">
+
                 <div class="container">
-                    <div class="tabs">
-                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-all" id="#all-tab" checked>
-                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-element" id="#element-tab">
-                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-container" id="#container-tab">
-                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-template" id="#template-tab">
+                    <div class="tabs__scroller">
+                        <label class="tabs__menu-label tabs__menu-label_all" for="#all-tab">All components</label>
+                        <label class="tabs__menu-label tabs__menu-label_element" for="#element-tab">Elements</label>
+                        <label class="tabs__menu-label tabs__menu-label_container" for="#container-tab">Containers</label>
+                        <label class="tabs__menu-label tabs__menu-label_template" for="#template-tab">Templates</label>
+                        <div class="tabs__menu-selector tabs__menu-selector_all"></div>
+                        <div class="tabs__menu-selector tabs__menu-selector_element"></div>
+                        <div class="tabs__menu-selector tabs__menu-selector_container"></div>
+                        <div class="tabs__menu-selector tabs__menu-selector_template"></div>
+                    </div>
+                </div>
 
-                        <div class="tabs__scroller">
-                            <label class="tabs__menu-label tabs__menu-label-all" for="#all-tab">All components</label>
-                            <label class="tabs__menu-label tabs__menu-label-element" for="#element-tab">Elements</label>
-                            <label class="tabs__menu-label tabs__menu-label-container" for="#container-tab">Containers</label>
-                            <label class="tabs__menu-label tabs__menu-label-template" for="#template-tab">Templates</label>
-                            <div class="tabs__menu-selector tabs__menu-selector-all"></div>
-                            <div class="tabs__menu-selector tabs__menu-selector-element"></div>
-                            <div class="tabs__menu-selector tabs__menu-selector-container"></div>
-                            <div class="tabs__menu-selector tabs__menu-selector-template"></div>
-                        </div>
-
+                <div class="tabs__main">
+                    <div class="container">
                         <div class="tabs__content tabs__content_element">
                             <div class="card"></div>
                             <div class="card"></div>

--- a/index.html
+++ b/index.html
@@ -29,32 +29,34 @@
                 <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_container" id="#container-tab">
                 <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item_template" id="#template-tab">
 
-                <div class="container">
-                    <div class="tabs__scroller">
-                        <label class="tabs__menu-label tabs__menu-label_all" for="#all-tab">All components</label>
-                        <label class="tabs__menu-label tabs__menu-label_element" for="#element-tab">Elements</label>
-                        <label class="tabs__menu-label tabs__menu-label_container" for="#container-tab">Containers</label>
-                        <label class="tabs__menu-label tabs__menu-label_template" for="#template-tab">Templates</label>
-                        <div class="tabs__menu-selector tabs__menu-selector_all"></div>
-                        <div class="tabs__menu-selector tabs__menu-selector_element"></div>
-                        <div class="tabs__menu-selector tabs__menu-selector_container"></div>
-                        <div class="tabs__menu-selector tabs__menu-selector_template"></div>
+                <div class="tabs__scroller">
+                    <label class="tabs__menu-label tabs__menu-label_all" for="#all-tab">All components</label>
+                    <label class="tabs__menu-label tabs__menu-label_element" for="#element-tab">Elements</label>
+                    <label class="tabs__menu-label tabs__menu-label_container" for="#container-tab">Containers</label>
+                    <label class="tabs__menu-label tabs__menu-label_template" for="#template-tab">Templates</label>
+                    <div class="tabs__menu-selector tabs__menu-selector_all"></div>
+                    <div class="tabs__menu-selector tabs__menu-selector_element"></div>
+                    <div class="tabs__menu-selector tabs__menu-selector_container"></div>
+                    <div class="tabs__menu-selector tabs__menu-selector_template"></div>
+                </div>
+                <div class="tabs__content tabs__content_element">
+                    <div class="container">
+                        <div class="preview preview__cards">
+                            <div class="card"></div>
+                            <div class="card"></div>
+                            <div class="card"></div>
+                        </div>
                     </div>
                 </div>
-
-                <div class="tabs__main">
+                <div class="tabs__content tabs__content_container">
                     <div class="container">
-                        <div class="tabs__content tabs__content_element">
-                            <div class="card"></div>
-                            <div class="card"></div>
-                            <div class="card"></div>
-                        </div>
-                        <div class="tabs__content tabs__content_container">
-                            Контейнеры
-                        </div>
-                        <div class="tabs__content tabs__content_template">
-                            Темплейты
-                        </div>
+
+                        Контейнеры
+                    </div>
+                </div>
+                <div class="tabs__content tabs__content_template">
+                    <div class="container">
+                        Темплейты
                     </div>
                 </div>
             </main>

--- a/index.html
+++ b/index.html
@@ -25,19 +25,45 @@
             </header>
             <main class="preview page__main">
                 <div class="container">
-                    <div class="preview__cards">
-                        <div class="card"></div>
-                        <div class="card"></div>
-                        <div class="card"></div>
+                    <div class="tabs">
+                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-all" id="#all-tab" checked>
+                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-element" id="#element-tab">
+                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-container" id="#container-tab">
+                        <input type="radio" name="menu" class="tabs__menu-item tabs__menu-item-template" id="#template-tab">
+
+                        <div class="tabs__scroller">
+                            <label class="tabs__menu-label tabs__menu-label-all" for="#all-tab">All components</label>
+                            <label class="tabs__menu-label tabs__menu-label-element" for="#element-tab">Elements</label>
+                            <label class="tabs__menu-label tabs__menu-label-container" for="#container-tab">Containers</label>
+                            <label class="tabs__menu-label tabs__menu-label-template" for="#template-tab">Templates</label>
+                            <div class="tabs__menu-selector tabs__menu-selector-all"></div>
+                            <div class="tabs__menu-selector tabs__menu-selector-element"></div>
+                            <div class="tabs__menu-selector tabs__menu-selector-container"></div>
+                            <div class="tabs__menu-selector tabs__menu-selector-template"></div>
+                        </div>
+
+                        <div class="tabs__content tabs__content_element">
+                            <div class="card"></div>
+                            <div class="card"></div>
+                            <div class="card"></div>
+                        </div>
+                        <div class="tabs__content tabs__content_container">
+                            Контейнеры
+                        </div>
+                        <div class="tabs__content tabs__content_template">
+                            Темплейты
+                        </div>
                     </div>
                 </div>
             </main>
             <footer class="footer">
-                <div class="footer__inner">
-                    <h2 class="footer__title">About</h2>
-                    <p class="footer__text">
-                        This project is a collection of professionally designed, pre-built, fully responsive HTML snippets you can drop into your projects. Get started by checking out our free preview components, or browsing the PNG previews in the categories you're most curious about.
-                    </p>
+                <div class="container">
+                    <div class="footer__inner">
+                        <h2 class="footer__title">About</h2>
+                        <p class="footer__text">
+                            This project is a collection of professionally designed, pre-built, fully responsive HTML snippets you can drop into your projects. Get started by checking out our free preview components, or browsing the PNG previews in the categories you're most curious about.
+                        </p>
+                    </div>
                 </div>
             </footer>
         </div>


### PR DESCRIPTION
Теоретически табуляция работает. Но
1. Не смог сделать серый фон для content-части растянутым на всю ширину страницы. И табы и контент уже внутри одного контейнера и не получилось их разделить по разным
2. Напрягают громоздкие конструкции для описания модификаций для псевдоклассов `:checked` `:hover` и тп. Есть подозрение, что это можно сделать как-то проще